### PR TITLE
Delete container after wf run

### DIFF
--- a/packages/wf-docker-workflow/src/opt/wf-docker-workflow/host/bin/workflow_runner.sh
+++ b/packages/wf-docker-workflow/src/opt/wf-docker-workflow/host/bin/workflow_runner.sh
@@ -162,6 +162,7 @@ fi
 
 # You should handle the `WF_DOCKER_HOST_CHAIN` as unique, because the quotes cause some problem if you want to use in an other variable!
 docker run ${TTY} \
+            --rm \
             ${DOCKER_COMPOSE_ENV} \
             -e WF_DOCKER_HOST_CHAIN="${WF_DOCKER_HOST_CHAIN}" \
             -w ${WORKDIR} \


### PR DESCRIPTION
Containers are created for every wf command and those containers are left unused after. Easiest solution is to delete them after they exit with the `--rm` option.